### PR TITLE
"Validate" SV by re-genotyping them

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,33 @@ Simple variant annotation.
     - Small variants are annotated with with gnomAD's allele frequencies, and ClinVar's clinical significance.
     - Structural variants are annotated with the frequency in SV catalogs, and their overlap with dbVar clinical SVs, or DGV.
 
+## Inputs
+
+### Gene annotation
+
+If `SNPEFF_DB` and `SNPEFF_DB_NAME` are provided, SNPeff will annotate variants with their impact based on the gene annotation.
+
+### Small variant databases
+
+If `GNOMAD_VCF`, `GNOMAD_VCF_INDEX`, `CLINVAR_VCF`, `CLINVAR_VCF_INDEX`, `DBNSFP_DB`, and `DBNSFP_DB_INDEX` are provided, SNPeff/SNPsift will annotate small variants with:
+
+- their frequency in gnomAD
+- their presence and clinical significance in ClinVar
+- the predicted impact based on conservation (GERP++), CADD, or MetaRNN.
+
+### Structural variant databases
+
+If `SV_DB_RDATA` is providd, SVs are annotated with:
+
+- the frequency of similar SVs in public SV catalogs
+- their similarity with variants in DGV
+- their similarity with the Clinical SV dataset from dbVar
+
+### Structural variant validation
+
+If `BAM`, `BAM_INDEX`, and `REFERENCE_FASTA` are provided, SVs will be re-genotyped from the long reads using local pangenomes built with vg.
+A new INFO field called *VAL* will represent the read support for the alternate allele.
+
 ## Test locally
 
 ```

--- a/docker/svvalidate_vgcall/Dockerfile
+++ b/docker/svvalidate_vgcall/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:20.04
+MAINTAINER jmonlong@ucsc.edu
+
+# Prevent dpkg from trying to ask any questions, ever
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    wget \
+    gcc \
+    git \
+    make \
+    bzip2 \
+    tabix \
+    python3 \
+    python3-pip \
+    libncurses5-dev \
+    libncursesw5-dev \
+    zlib1g-dev \
+    libbz2-dev \
+    liblzma-dev \
+    autoconf \
+    build-essential \
+    pkg-config \
+    apt-transport-https software-properties-common dirmngr gpg-agent \
+    && rm -rf /var/lib/apt/lists/*
+
+## samtools
+RUN wget --no-check-certificate https://github.com/samtools/samtools/releases/download/1.17/samtools-1.17.tar.bz2 && \
+    tar -xjvf samtools-1.17.tar.bz2 && \
+    cd samtools-1.17 && \
+    ./configure && \
+    make && \
+    make install
+
+## vg
+WORKDIR /bin
+RUN wget --no-check-certificate https://github.com/vgteam/vg/releases/download/v1.48.0/vg && \
+    chmod +x vg
+ENV PATH=$PATH:/bin
+
+## minigraph
+RUN git clone https://github.com/lh3/minigraph.git && \
+    cd minigraph && \
+    make
+ENV PATH=$PATH:/bin/minigraph
+
+# python packages
+RUN pip3 install cyvcf2
+
+# add script
+WORKDIR /opt/scripts
+ADD validate-svs.py /opt/scripts
+
+WORKDIR /home

--- a/docker/svvalidate_vgcall/README.md
+++ b/docker/svvalidate_vgcall/README.md
@@ -1,0 +1,20 @@
+Container to validate SVs by re-genotyping a SV candidate with vg
+
+The [`validate-svs.py`](validate-svs.py) script is included (available at `/opt/scripts/validate-svs.py` in the container).
+It will construct a local pangenome for each SV, map long reads with minigraph, and genotype them with `vg pack/call`.
+
+The inputs of `validate-svs.py` are:
+
+```
+root@d012132f9326:/home# python3 /opt/scripts/validate-svs.py --help
+usage: validate-svs.py [-h] -b B -f F -v V [-d D] [-o O] [-t T]
+
+optional arguments:
+  -h, --help  show this help message and exit
+  -b B        BAM file (indexed)
+  -f F        reference FASTA file (indexed)
+  -v V        variants in VCF (can be bgzipped)
+  -d D        output directory
+  -o O        output (annotated) VCF (will be bgzipped if ending in .gz)
+  -t T        number of threads used by the tools (vg and minigraph))
+```

--- a/docker/svvalidate_vgcall/validate-svs.py
+++ b/docker/svvalidate_vgcall/validate-svs.py
@@ -1,0 +1,126 @@
+import argparse
+from subprocess import run
+from cyvcf2 import VCF, Writer
+import os
+import sys
+import hashlib
+
+
+# function to write a VCF for one SV
+# that VCF file is later used to build a pangenome
+def write_single_sv_vcf(sv_info, vcf_path):
+    outf = open(vcf_path, 'wt')
+    outf.write("##fileformat=VCFv4.2\n")
+    outf.write("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n")
+    outf.write("{seqn}\t{pos}\t.\t{ref}\t{alt}\t.\t.\t.\n".format(seqn=sv_info['seqn'],
+                                                                  pos=sv_info['start'],
+                                                                  ref=sv_info['ref'],
+                                                                  alt=sv_info['alt']))
+    outf.close()
+    bgzip_args = ["bgzip", "-c", vcf_path]
+    vcf_path_gz = vcf_path + '.gz'
+    with open(vcf_path_gz, 'w') as file:
+        run(bgzip_args, check=True, stdout=file, stderr=sys.stderr, universal_newlines=True)
+    tabix_args = ["tabix", vcf_path_gz]
+    run(tabix_args, check=True, stdout=sys.stdout, stderr=sys.stderr, universal_newlines=True)
+    return(vcf_path_gz)
+
+# function to evaluate a SV
+# sv_info is a dict with a 'svid', position and ref/alt sequences information
+def evaluate_sv(sv_info, ref_fa_path, bam_path, output_dir, debug_mode=False, nb_cores=2):
+    dump = open('/dev/null', 'w')
+    # make VCF with just the one SV
+    vcf_path = os.path.join(output_dir, sv_info['svid'] + ".vcf")
+    vcf_path_gz = write_single_sv_vcf(sv_info, vcf_path)
+    # decide on the region to consider (SV + flanks?)
+    flank_size_vg = 50000
+    region_coord_vg = '{}:{}-{}'.format(sv_info['seqn'],
+                                        sv_info['start'] - flank_size_vg,
+                                        sv_info['end'] + flank_size_vg)
+    flank_size = 10000
+    region_coord = '{}:{}-{}'.format(sv_info['seqn'],
+                                     sv_info['start'] - flank_size,
+                                     sv_info['end'] + flank_size)
+    # make graph with SV
+    construct_args = ["vg", "construct", "-a", "-m", "1024", "-S",
+                      "-r", ref_fa_path, "-v", vcf_path_gz, "-R", region_coord_vg]
+    vg_output_path = os.path.join(output_dir, sv_info['svid'] + ".vg")
+    with open(vg_output_path, 'w') as file:
+        run(construct_args, check=True, stdout=file, stderr=sys.stderr, universal_newlines=True)
+    # extract reads
+    extract_args = ["samtools", "view", "-h", bam_path, region_coord]
+    sam_output_path = os.path.join(output_dir, sv_info['svid'] + ".sam")
+    with open(sam_output_path, 'w') as file:
+        run(extract_args, check=True, stdout=file, stderr=sys.stderr, universal_newlines=True)
+    extract_args = ["samtools", "fasta", sam_output_path]
+    fa_output_path = os.path.join(output_dir, sv_info['svid'] + ".fasta")
+    with open(fa_output_path, 'w') as file:
+        run(extract_args, check=True, stdout=file, stderr=dump, universal_newlines=True)
+    # align reads to pangenome
+    convert_args = ["vg", "convert", "-f", vg_output_path]
+    gfa_output_path = os.path.join(output_dir, sv_info['svid'] + ".gfa")
+    with open(gfa_output_path, 'w') as file:
+        run(convert_args, check=True, stdout=file, stderr=sys.stderr, universal_newlines=True)    
+    map_args = ["minigraph", "-t", str(nb_cores), "-c", gfa_output_path, fa_output_path]
+    gaf_output_path = os.path.join(output_dir, sv_info['svid'] + ".gaf")
+    with open(gaf_output_path, 'w') as file:
+        run(map_args, check=True, stdout=file, stderr=dump, universal_newlines=True)    
+    # genotype SV
+    pack_output_path = os.path.join(output_dir, sv_info['svid'] + ".pack")
+    pack_args = ["vg", "pack", "-t", str(nb_cores), "-e",
+                 "-x", vg_output_path, "-o", pack_output_path, '-a', gaf_output_path]
+    run(pack_args, check=True, stdout=sys.stdout, stderr=sys.stderr, universal_newlines=True)    
+    call_args = ["vg", "call", "-t", str(nb_cores),
+                 "-k", pack_output_path, '-v', vcf_path, vg_output_path]
+    call_output_path = os.path.join(output_dir, sv_info['svid'] + ".called.vcf")
+    with open(call_output_path, 'w') as file:
+        run(call_args, check=True, stdout=file, stderr=sys.stderr, universal_newlines=True)    
+    # update SV information or return a score
+    score = -1
+    for variant in VCF(call_output_path):
+        ad = variant.format('AD')[0]
+        score = float(ad[1]) / (ad[0] + ad[1])
+    # remove intermediate files
+    if not debug_mode:
+        for ff in [sam_output_path, vg_output_path, fa_output_path, gfa_output_path,
+                   gaf_output_path, pack_output_path, call_output_path,
+                   vcf_path, vcf_path_gz, vcf_path_gz + '.tbi']:
+            os.remove(ff)
+    dump.close()
+    return(score)
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-b', help='BAM file (indexed)', required=True)
+parser.add_argument('-f', help='reference FASTA file (indexed)', required=True)
+parser.add_argument('-v', help='variants in VCF (can be bgzipped)', required=True)
+parser.add_argument('-d', help='output directory', default='temp_valsv')
+parser.add_argument('-o', help='output (annotated) VCF (will be bgzipped if ending in .gz)', default='out.vcf')
+parser.add_argument('-t', help='number of threads used by the tools (vg and minigraph))', default=2)
+args = parser.parse_args()
+
+DEBUG_MODE = True
+
+vcf = VCF(args.v)
+vcf.add_info_to_header({'ID': 'VAL', 'Description': 'Validation score from vg genotyping',
+    'Type':'Float', 'Number': '1'})
+vcf_o = Writer(args.o, vcf)
+
+# Read VCF and evaluate each SV
+for variant in vcf:
+    if len(variant.REF) > 30 or len(variant.ALT[0]) > 30:
+        svinfo = {}
+        svinfo['ref'] = variant.REF
+        svinfo['alt'] = variant.ALT[0]
+        svinfo['seqn'] = variant.CHROM
+        svinfo['start'] = variant.start + 1
+        svinfo['end'] = variant.end + 1
+        seq = '{}_{}'.format(variant.REF, variant.ALT[0])
+        seq = hashlib.sha1(seq.encode())
+        svinfo['svid'] = '{}_{}_{}'.format(variant.CHROM,
+                                              variant.start,
+                                              seq.hexdigest())
+        variant.INFO["VAL"] = evaluate_sv(svinfo, args.f, args.b, args.d, DEBUG_MODE, nb_cores=args.t)
+    vcf_o.write_record(variant)
+
+vcf_o.close()
+vcf.close()

--- a/wdl/workflow.wdl
+++ b/wdl/workflow.wdl
@@ -349,7 +349,7 @@ task validate_svs_with_vg {
         memory: memSizeGB + " GB"
         cpu: threadCount
         disks: "local-disk " + diskSizeGB + " SSD"
-        docker: "quay.io/jmonlong/svvalidate_vgcall:validate_sv"
+        docker: "quay.io/jmonlong/svvalidate_vgcall:0.1"
         preemptible: 1
     }
 }

--- a/wdl/workflow.wdl
+++ b/wdl/workflow.wdl
@@ -21,6 +21,9 @@ workflow annotate_variants {
         SORT_INDEX_VCF: "Should the output VCF be sorted, bgzipped, and indexed? Default: true"
         DBNSFP_DB: "dbNSFP annotation bundle (block-gzip)"
         DBNSFP_DB_INDEX: "Index for DBNSFP_DB"
+        BAM: "Sorted and indexed BAM with the long reads. Optional. If present, SVs will be re-genotyped to help filtering false-positives out."
+        BAM_INDEX: "Index for BAM"
+        REFERENCE_FASTA: "Reference fasta. Optional. Used for SV in silico validation when BAM and BAM_INDEX are provided."
     }
     
     input {
@@ -34,6 +37,9 @@ workflow annotate_variants {
         File? SV_DB_RDATA
         File? DBNSFP_DB
         File? DBNSFP_DB_INDEX
+        File? BAM
+        File? BAM_INDEX
+        File? REFERENCE_FASTA
         Boolean SPLIT_MULTIAL = true
         Boolean SORT_INDEX_VCF = true
     }
@@ -88,15 +94,28 @@ workflow annotate_variants {
     
     File sv_annotated_vcf = select_first([annotate_sv_with_db.vcf, small_annotated_vcf])
 
+    # regenotype SVs with local pangenomes using vg to provide some in silico "validation"
+    if (defined(BAM) && defined(BAM_INDEX) && defined(REFERENCE_FASTA)){
+        call validate_svs_with_vg {
+            input:
+            input_vcf=sv_annotated_vcf,
+            bam=select_first([BAM]),
+            bam_index=select_first([BAM_INDEX]),
+            reference_fasta=select_first([REFERENCE_FASTA])
+        }
+    }
+
+    File sv_validated_vcf = select_first([validate_svs_with_vg.vcf, sv_annotated_vcf])
+
     # sort annotated VCF
     if (SORT_INDEX_VCF){
         call sort_vcf {
             input:
-            input_vcf=sv_annotated_vcf
+            input_vcf=sv_validated_vcf
         }
     }
     
-    File final_vcf = select_first([sort_vcf.vcf, sv_annotated_vcf])
+    File final_vcf = select_first([sort_vcf.vcf, sv_validated_vcf])
     
     output {
         File vcf = final_vcf
@@ -289,6 +308,48 @@ task annotate_sv_with_db {
         cpu: threadCount
         disks: "local-disk " + diskSizeGB + " SSD"
         docker: "quay.io/jmonlong/svannotate_sveval:0.2"
+        preemptible: 1
+    }
+}
+
+task validate_svs_with_vg {
+    input {
+        File input_vcf
+        File bam
+        File bam_index
+        File reference_fasta
+        Int memSizeGB = 8
+        Int threadCount = 4
+        Int diskSizeGB = 5*round(size(input_vcf, "GB") + size(bam, 'GB') + size(reference_fasta, 'GB')) + 30
+    }
+
+    String basen = sub(sub(basename(input_vcf), ".vcf.bgz$", ""), ".vcf.gz$", "")
+    
+    command <<<
+        set -eux -o pipefail
+
+        ## link and index reference fasta
+        ln -s ~{reference_fasta} ref.fa
+        samtools faidx ref.fa
+
+        ## link BAM file and index to make sure the index is found
+        ln -s ~{bam} reads.bam
+        ln -s ~{bam_index} reads.bam.bai
+        
+        # annotate SVs
+        mkdir temp
+        python3 /opt/scripts/validate-svs.py -b reads.bam -f ref.fa -v ~{input_vcf} -d temp -o ~{basen}.svval.vcf.gz -t ~{threadCount}
+    >>>
+
+    output {
+        File vcf = "~{basen}.svval.vcf.gz"
+    }
+
+    runtime {
+        memory: memSizeGB + " GB"
+        cpu: threadCount
+        disks: "local-disk " + diskSizeGB + " SSD"
+        docker: "quay.io/jmonlong/svvalidate_vgcall:validate_sv"
         preemptible: 1
     }
 }


### PR DESCRIPTION
SVs may not have information about the confidence of the call/genotype. We end up having to use gross filters, like removing SVs that overlap segmental duplications, to minimize the number of false calls. Doing that, we throw away half of the SVs, including some that might be important and supported by reads. 

This PR adds a new task to help identify the SVs that are supported by reads. For each candidate SV, it will:

1. create a local pangenome with the candidate SV using vg
2. extract long reads from that region
3. align the reads to the pangenome (currently with minigraph)
4. genotype the SV with vg
5. annotate the original VCF with the read support (as the proportion of reads supporting the alternate allele, i.e. the SV).

This additional annotation/validation task is triggered by providing reads and a reference genome with the `BAM`, `BAM_INDEX`, and `REFERENCE_FASTA` input parameters.